### PR TITLE
Rework RESET/END ordering: reset arms, END fires end-of-cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,10 @@ GitHub release.
   gate, holding the CV outputs, and the next TRIG plays datapoint 0 in
   time with the clock. END fires as the last datapoint plays
   (end-of-cycle), so an END → RESET loop is gapless (N datapoints = N
-  clock ticks) and resets are always in time.
+  clock ticks) and resets are always in time. The display playhead
+  tracks what's sounding, not the armed position: it stays on the
+  last-played datapoint through a reset until the next TRIG, and
+  disappears if the playhead runs past the end without a reset.
 - Columns with no numeric values can't be selected (greyed out in the
   menu); a file with no numeric columns at all is an invalid CSV.
 - Flat data (all values identical, incl. single-row files) maps to the
@@ -68,7 +71,8 @@ GitHub release.
 - `process()` runs on the audio thread; `processCSV()` and the DataViz widget
   run on UI-side threads. Loaded data crosses that boundary only as an
   immutable `Dataset` snapshot published via `getDataset()`/`setDataset()`;
-  the remaining shared scalars (`row`, `badcsv`, `resetarmed`) are atomics.
+  the remaining shared scalars (`row`, `playingrow`, `badcsv`,
+  `resetarmed`) are atomics.
   Don't add unsynchronized shared state — extend the snapshot, or use an
   atomic, instead.
 - The owner develops on macOS only; Windows/Linux verification happens via CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,13 @@ lin-x64, mac-x64, and mac-arm64 on every push and uploads `.vcvplugin`
 artifacts; a `v*` tag that matches the `plugin.json` version creates a
 GitHub release.
 
+After every push that triggers a CI build, without being asked, give the
+owner: (1) a link to the workflow run so they can download the
+**mac-arm64** artifact from its Artifacts section, and (2) the install
+path — drop the `.vcvplugin` into
+`~/Library/Application Support/Rack2/plugins-mac-arm64` (don't extract
+it) and restart Rack.
+
 ## Releasing to the VCV Library
 
 1. Bump `version` in `plugin.json` (Rack 2 versions look like `2.x.y`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,13 @@ it) and restart Rack.
   time with the clock. END fires as the last datapoint plays
   (end-of-cycle), so an END → RESET loop is gapless (N datapoints = N
   clock ticks) and resets are always in time. The display playhead
-  tracks what's sounding, not the armed position: it stays on the
-  last-played datapoint through a reset until the next TRIG, and
-  disappears if the playhead runs past the end without a reset.
+  tracks what's sounding, not the armed position: a filled circle marks
+  the last-played datapoint, and a hollow circle on datapoint 0 means
+  the sequence is cued but hasn't begun (fresh data, or a manual
+  reset). A reset arriving while END is still high counts as an
+  END → RESET loop reset instead: the filled circle stays on the last
+  datapoint while it plays out. The circle disappears if the playhead
+  runs past the end without a reset.
 - Columns with no numeric values can't be selected (greyed out in the
   menu); a file with no numeric columns at all is an invalid CSV.
 - Flat data (all values identical, incl. single-row files) maps to the
@@ -78,7 +82,7 @@ it) and restart Rack.
 - `process()` runs on the audio thread; `processCSV()` and the DataViz widget
   run on UI-side threads. Loaded data crosses that boundary only as an
   immutable `Dataset` snapshot published via `getDataset()`/`setDataset()`;
-  the remaining shared scalars (`row`, `playingrow`, `badcsv`,
+  the remaining shared scalars (`row`, `playingrow`, `cued`, `badcsv`,
   `resetarmed`) are atomics.
   Don't add unsynchronized shared state — extend the snapshot, or use an
   atomic, instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,14 @@ it) and restart Rack.
   END → RESET loop reset instead: the filled circle stays on the last
   datapoint while it plays out. The circle disappears if the playhead
   runs past the end without a reset.
+  Known edge cases of the "END still high" test (owner-approved,
+  display-only — the sequencing is identical either way): a manual
+  reset landing inside END's 10ms pulse reads as a loop reset, so no
+  hollow circle appears; an END → RESET connection routed through
+  modules that delay the trigger by more than 10ms reads as manual, so
+  the hollow circle flashes at each loop point. And since a missing
+  (NaN) datapoint 0 has no vertical position, no cue circle is drawn
+  while cued on it.
 - Columns with no numeric values can't be selected (greyed out in the
   menu); a file with no numeric columns at all is an invalid CSV.
 - Flat data (all values identical, incl. single-row files) maps to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,12 @@ GitHub release.
   gate (missing data is audible as silence).
 - V/oct RANGE mapping is intentionally asymmetric: ranges 1-3 octaves span
   0V..+range; 4-8 pin the top at +4V and grow downward.
-- Looping is done by the user patching END → RESET, not built in.
+- Looping is done by the user patching END → RESET, not built in. RESET
+  arms rather than plays: it returns the playhead to datapoint 0 with no
+  gate, holding the CV outputs, and the next TRIG plays datapoint 0 in
+  time with the clock. END fires as the last datapoint plays
+  (end-of-cycle), so an END → RESET loop is gapless (N datapoints = N
+  clock ticks) and resets are always in time.
 - Columns with no numeric values can't be selected (greyed out in the
   menu); a file with no numeric columns at all is an invalid CSV.
 - Flat data (all values identical, incl. single-row files) maps to the
@@ -61,8 +66,9 @@ GitHub release.
 ## Known constraints
 
 - `process()` runs on the audio thread; `processCSV()` and the DataViz widget
-  run on UI-side threads. They currently share mutable state (`data`,
-  `datamin`, `datamax`, `datalength`, `row`) without synchronization — the
-  suspected cause of the crashes in issue #4. Don't add more unsynchronized
-  shared state; the planned fix is to publish an immutable dataset snapshot.
+  run on UI-side threads. Loaded data crosses that boundary only as an
+  immutable `Dataset` snapshot published via `getDataset()`/`setDataset()`;
+  the remaining shared scalars (`row`, `badcsv`, `resetarmed`) are atomics.
+  Don't add unsynchronized shared state — extend the snapshot, or use an
+  atomic, instead.
 - The owner develops on macOS only; Windows/Linux verification happens via CI.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Right-click to load a CSV file, and then right-click again to select a column of
 
 Your CSV file must have a single header row containing column names, and you'll only be able to sonify columns containing numbers. Any missing or non-numeric values in your data will be replaced with null values that don't fire a gate.
 
-Send a trigger signal into the TRIG input to process the first datapoint and move to the next one. Send a trigger into the RESET input to return to the start of the dataset.
+Send a trigger signal into the TRIG input to process the first datapoint and move to the next one. Send a trigger into the RESET input to return to the start of the dataset — nothing plays until the next trigger arrives at TRIG, which plays the first datapoint in time with your clock. The END output fires a trigger as the last datapoint plays, so patching END → RESET loops the dataset seamlessly.
 
 The top two outputs generate voltages from -5V to 5V and 0 to 10V respectively. The lower left output generates 1V/Oct pitch CV, scaled to the number of octaves selected using the RANGE knob. The lower right output generates a gate as each new datapoint is processed - change the lenth of this gate with the LENGTH knob.
 
@@ -28,7 +28,7 @@ A: Use [CSVLint](https://csvlint.io/) to check if your CSV is valid. If it is, s
 
 **Q: I'm getting crashes when loading a CSV file**
 
-This is likely a text encoding issue with the CSV library, which I'm [working on a solution for](https://github.com/loudnumbers/loudnumbers_vcv/issues/4). In the meantime, try re-encoding your csv file to UTF-8, which should fix it.
+A: This should be fixed in recent versions. If you're still seeing a crash, please submit an issue and attach the CSV file you're trying to load. Re-encoding your csv file to UTF-8 may help in the meantime.
 
 **Q: How do I make the output sound more musical?**
 

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -150,13 +150,16 @@ struct LoudNumbers : Module
 	std::atomic<bool> badcsv{false};
 	std::atomic<int> row{-1}; // because the first thing we do is increment it
 
+	// Set when a reset has moved the playhead back to the first datapoint
+	// but it hasn't played yet: the next TRIG should play datapoint 0
+	// instead of stepping past it. Atomic because processCSV() (UI thread)
+	// clears it while process() (audio thread) reads it.
+	std::atomic<bool> resetarmed{false};
+
 	// Style variables
 	std::string main = "#003380";
 	std::string faded = "#805279";
 	std::string white = "#FFFBE4";
-
-	// Variables to track what's happening
-	bool rowadvanced = false;
 
 	// Save and retrieve menu choice(s).
 	json_t* dataToJson() override {
@@ -202,6 +205,32 @@ struct LoudNumbers : Module
 	dsp::PulseGenerator gatePulse;
 	dsp::PulseGenerator endPulse;
 
+	// Set the three CV outputs to datapoint r of the dataset. The caller
+	// checks that r is in range and not a NaN (missing) value.
+	void setCVOutputs(const Dataset &ds, int r)
+	{
+		// Get v/oct min and max: ranges of 1-3 octaves span 0V up to
+		// +range; from 4 octaves the top pins at +4V and grows downward.
+		float voctmin;
+		float voctmax;
+
+		if (params[RANGE_PARAM].getValue() < 4)
+		{
+			voctmin = 0;
+			voctmax = params[RANGE_PARAM].getValue();
+		}
+		else
+		{
+			voctmin = 4 - params[RANGE_PARAM].getValue();
+			voctmax = 4;
+		}
+
+		// Set the voltages to the data
+		outputs[MINUSFIVETOFIVE_OUTPUT].setVoltage(scalemap(ds.data[r], ds.datamin, ds.datamax, -5.f, 5.f));
+		outputs[ZEROTOTEN_OUTPUT].setVoltage(scalemap(ds.data[r], ds.datamin, ds.datamax, 0.f, 10.f));
+		outputs[VOCT_OUTPUT].setVoltage(scalemap(ds.data[r], ds.datamin, ds.datamax, voctmin, voctmax));
+	}
+
 	// On a loop
 	void process(const ProcessArgs &args) override
 	{
@@ -216,77 +245,58 @@ struct LoudNumbers : Module
 		std::shared_ptr<const Dataset> ds = getDataset();
 		int len = ds->length();
 
-		// If a gate is high in the trigger input, advance the row and set rowadvanced flag
-		if (ingate.process(inputs[TRIG_INPUT].getVoltage()))
-		{
-			// Increment the row number
-			row++;
-
-			// Check if row has hit max and trigger an end pulse if so.
-			// (No data loaded means no end to reach, so no pulse.)
-			if (len > 0 && row >= len)
-			{
-				endPulse.trigger(0.01);
-			}
-
-			// Get ready to play a note
-			rowadvanced = true;
-		}
-
-		// Activate end pulse if triggered
-		bool epulse = endPulse.process(1.0 / args.sampleRate);
-		outputs[END_OUTPUT].setVoltage(epulse ? 10.0 : 0.0);
-
-		// If a reset gate is received, return to the first datapoint
+		// A trigger at RESET arms the sequence: the playhead returns to
+		// the first datapoint, but no gate fires and the CV outputs hold
+		// their last values. The next TRIG then plays datapoint 0 in time
+		// with the clock. With END -> RESET patched, the reset arms while
+		// the last note is still sounding, so the loop stays gapless
+		// (N datapoints = N clock ticks).
 		if (resetgate.process(inputs[RESET_INPUT].getVoltage()))
 		{
 			row = 0;
-			rowadvanced = true;
-
-			// If the first datapoint is missing, reset the outputs to 0.
-			// (Otherwise the rowadvanced block below plays it.)
-			if (len == 0 || std::isnan(ds->data[0]))
-			{
-				outputs[MINUSFIVETOFIVE_OUTPUT].setVoltage(0.f);
-				outputs[ZEROTOTEN_OUTPUT].setVoltage(0.f);
-				outputs[VOCT_OUTPUT].setVoltage(0.f);
-			}
+			resetarmed = true;
 		}
 
-		// If rowadvanced flag is set
-		if (rowadvanced)
+		// If a gate is high in the trigger input, play the next datapoint
+		if (ingate.process(inputs[TRIG_INPUT].getVoltage()))
 		{
+			if (resetarmed)
+			{
+				// A reset already moved the playhead to the first
+				// datapoint; play that rather than stepping past it.
+				resetarmed = false;
+			}
+			else
+			{
+				// Increment the row number
+				row++;
+			}
+
 			int r = row;
-			if (r >= 0 && r < len) {
-				rowadvanced = false;
-
-				// Get v/oct min and max
-				float voctmin;
-				float voctmax;
-
-				if (params[RANGE_PARAM].getValue() < 4)
+			if (r >= 0 && r < len)
+			{
+				// If it's not a NaN (missing) value, play it. Missing
+				// data fires no gate and the CV outputs hold, so it's
+				// audible as silence.
+				if (!std::isnan(ds->data[r]))
 				{
-					voctmin = 0;
-					voctmax = params[RANGE_PARAM].getValue();
-				}
-				else
-				{
-					voctmin = 4 - params[RANGE_PARAM].getValue();
-					voctmax = 4;
-				}
-
-				// If it's not a NaN (missing) value
-				if (!std::isnan(ds->data[r])) {
-					// Set the voltages to the data
-					outputs[MINUSFIVETOFIVE_OUTPUT].setVoltage(scalemap(ds->data[r], ds->datamin, ds->datamax, -5.f, 5.f));
-					outputs[ZEROTOTEN_OUTPUT].setVoltage(scalemap(ds->data[r], ds->datamin, ds->datamax, 0.f, 10.f));
-					outputs[VOCT_OUTPUT].setVoltage(scalemap(ds->data[r], ds->datamin, ds->datamax, voctmin, voctmax));
+					setCVOutputs(*ds, r);
 					gatePulse.trigger(params[LENGTH_PARAM].getValue());
 				}
+
+				// END fires as the last datapoint plays (end of cycle),
+				// so END -> RESET re-arms the sequence in time for the
+				// next clock tick to play datapoint 0.
+				if (r == len - 1)
+				{
+					endPulse.trigger(0.01);
+				}
 			}
 		}
 
-		// Activate gate pulse if triggered
+		// Activate end and gate pulses if triggered
+		bool epulse = endPulse.process(1.0 / args.sampleRate);
+		outputs[END_OUTPUT].setVoltage(epulse ? 10.0 : 0.0);
 		bool gpulse = gatePulse.process(1.0 / args.sampleRate);
 		outputs[GATE_OUTPUT].setVoltage(gpulse ? 10.0 : 0.0);
 	};
@@ -450,6 +460,7 @@ struct LoudNumbers : Module
 			colnum = col;
 			currentpath = path;
 			row = -1; // because the first thing we do is increment it
+			resetarmed = false; // fresh data starts unarmed
 			setDataset(ds);
 			badcsv = false;
 

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -156,6 +156,15 @@ struct LoudNumbers : Module
 	// clears it while process() (audio thread) reads it.
 	std::atomic<bool> resetarmed{false};
 
+	// The datapoint the display playhead sits on: the one most recently
+	// played. Unlike 'row', which a reset moves at arm time, this only
+	// changes when a TRIG actually plays, so the circle tracks what's
+	// sounding rather than where the playhead is armed. -1 means nothing
+	// is playing (before the first trigger, or after the playhead runs
+	// past the end of the data) and hides the circle. Atomic because the
+	// audio thread writes it and the DataViz widget reads it.
+	std::atomic<int> playingrow{-1};
+
 	// Style variables
 	std::string main = "#003380";
 	std::string faded = "#805279";
@@ -275,6 +284,10 @@ struct LoudNumbers : Module
 			int r = row;
 			if (r >= 0 && r < len)
 			{
+				// This datapoint is now the one sounding, so the display
+				// playhead moves here.
+				playingrow = r;
+
 				// If it's not a NaN (missing) value, play it. Missing
 				// data fires no gate and the CV outputs hold, so it's
 				// audible as silence.
@@ -291,6 +304,12 @@ struct LoudNumbers : Module
 				{
 					endPulse.trigger(0.01);
 				}
+			}
+			else
+			{
+				// The playhead has run past the end (no reset patched):
+				// nothing plays and the display playhead disappears.
+				playingrow = -1;
 			}
 		}
 
@@ -461,6 +480,7 @@ struct LoudNumbers : Module
 			currentpath = path;
 			row = -1; // because the first thing we do is increment it
 			resetarmed = false; // fresh data starts unarmed
+			playingrow = -1; // nothing is sounding until the first trigger
 			setDataset(ds);
 			badcsv = false;
 
@@ -537,8 +557,10 @@ struct DataViz : Widget
 				nvgStroke(args.vg);
 				nvgClosePath(args.vg);
 
-				// Draw a circle at the current datapoint
-				int r = module->row;
+				// Draw a circle at the datapoint that's currently
+				// sounding (not at 'row', which a reset moves before
+				// anything plays)
+				int r = module->playingrow;
 				if (r >= 0 && r < len && !std::isnan(ds->data[r]))
 				{
 					// Calculate x and y coords

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -165,10 +165,17 @@ struct LoudNumbers : Module
 	// audio thread writes it and the DataViz widget reads it.
 	std::atomic<int> playingrow{-1};
 
+	// Set while the sequence is cued at the start but hasn't begun
+	// playing: when data is (re)loaded, and after a manual reset. The
+	// display then shows a hollow circle on the first datapoint instead
+	// of a filled one. Atomic for the same reason as playingrow.
+	std::atomic<bool> cued{true};
+
 	// Style variables
 	std::string main = "#003380";
 	std::string faded = "#805279";
 	std::string white = "#FFFBE4";
+	std::string salmon = "#FF7272"; // panel background, fills the hollow circle
 
 	// Save and retrieve menu choice(s).
 	json_t* dataToJson() override {
@@ -264,6 +271,20 @@ struct LoudNumbers : Module
 		{
 			row = 0;
 			resetarmed = true;
+
+			// Manual resets and END -> RESET loop resets arrive as
+			// identical triggers, but the display treats them
+			// differently. A loop reset lands while our own END pulse is
+			// still high (the cable adds only a sample of delay), so in
+			// that case the filled circle stays on the last datapoint
+			// while it plays out. Any other reset is manual: the circle
+			// leaves the playing datapoint immediately and a hollow
+			// "cued" circle appears on datapoint 0 instead.
+			if (endPulse.remaining <= 0.f)
+			{
+				playingrow = -1;
+				cued = true;
+			}
 		}
 
 		// If a gate is high in the trigger input, play the next datapoint
@@ -285,8 +306,10 @@ struct LoudNumbers : Module
 			if (r >= 0 && r < len)
 			{
 				// This datapoint is now the one sounding, so the display
-				// playhead moves here.
+				// playhead moves here (as a filled circle, so the cued
+				// state ends).
 				playingrow = r;
+				cued = false;
 
 				// If it's not a NaN (missing) value, play it. Missing
 				// data fires no gate and the CV outputs hold, so it's
@@ -310,6 +333,7 @@ struct LoudNumbers : Module
 				// The playhead has run past the end (no reset patched):
 				// nothing plays and the display playhead disappears.
 				playingrow = -1;
+				cued = false;
 			}
 		}
 
@@ -481,6 +505,7 @@ struct LoudNumbers : Module
 			row = -1; // because the first thing we do is increment it
 			resetarmed = false; // fresh data starts unarmed
 			playingrow = -1; // nothing is sounding until the first trigger
+			cued = true; // show the hollow circle: cued at the start
 			setDataset(ds);
 			badcsv = false;
 
@@ -557,10 +582,15 @@ struct DataViz : Widget
 				nvgStroke(args.vg);
 				nvgClosePath(args.vg);
 
-				// Draw a circle at the datapoint that's currently
-				// sounding (not at 'row', which a reset moves before
-				// anything plays)
-				int r = module->playingrow;
+				// Draw the playhead circle. A hollow circle on the first
+				// datapoint means the sequence is cued there but hasn't
+				// begun (fresh data, or a manual reset); a filled circle
+				// marks the datapoint that's currently sounding (not
+				// 'row', which a reset moves before anything plays).
+				// Missing (NaN) datapoints have no vertical position, so
+				// no circle is drawn on them.
+				bool hollow = module->cued;
+				int r = hollow ? 0 : (int)module->playingrow;
 				if (r >= 0 && r < len && !std::isnan(ds->data[r]))
 				{
 					// Calculate x and y coords
@@ -570,8 +600,21 @@ struct DataViz : Widget
 													0.f, height-6));
 					nvgBeginPath(args.vg);
 					nvgCircle(args.vg, x, y, mm2px(circ_size));
-					nvgFillColor(args.vg, color::fromHexString(module->main));
-					nvgFill(args.vg);
+					if (hollow)
+					{
+						// Outline only: fill with the panel background so
+						// the circle reads as an empty slot
+						nvgFillColor(args.vg, color::fromHexString(module->salmon));
+						nvgFill(args.vg);
+						nvgStrokeColor(args.vg, color::fromHexString(module->main));
+						nvgStrokeWidth(args.vg, mm2px(0.3));
+						nvgStroke(args.vg);
+					}
+					else
+					{
+						nvgFillColor(args.vg, color::fromHexString(module->main));
+						nvgFill(args.vg);
+					}
 					nvgClosePath(args.vg);
 				}
 


### PR DESCRIPTION
Fixes #20.

## Sequencing changes

- **RESET arms instead of playing.** A trigger at RESET returns the playhead to datapoint 0 with no gate; the CV outputs hold their last values. The next TRIG plays datapoint 0 in time with the clock, so manual resets mid-performance no longer produce an out-of-clock note.
- **END fires as the last datapoint plays** (end-of-cycle) instead of one clock tick after the playhead runs past the end. With END → RESET patched, the reset arms while the last note is still sounding and the loop stays gapless (N datapoints = N clock ticks). Extra TRIGs past the end no longer re-fire END.
- One deviation from the issue sketch, agreed with the owner: the CV outputs **hold** on reset rather than moving to datapoint 0, so the still-sounding last note of a loop keeps its pitch (END now fires while that note's gate is open).
- The duplicated output-setting code from the old reset and rowadvanced blocks is factored into `setCVOutputs()`; the `rowadvanced` flag is gone.

## Display changes

- The playhead circle now tracks **what's sounding** (`playingrow`), not the armed `row`, fixing the last datapoint's circle vanishing after one sample and datapoint 0 appearing to play twice in a loop.
- A sequence that's cued but hasn't begun — fresh data, or a **manual** reset — shows a **hollow circle** (panel-salmon fill, outlined) on datapoint 0. The next TRIG fills it in.
- **END → RESET loop resets** are recognised because they arrive while the module's own END pulse is still high: the filled circle stays on the last datapoint while it plays out, and no hollow circle appears mid-loop.
- Known display-only edge cases of that test (documented in CLAUDE.md): a manual reset landing inside END's 10ms pulse reads as a loop reset; an END → RESET connection delayed by >10ms of intermediate modules reads as manual. Sequencing is identical either way.

## Docs

- README: RESET/END behaviour and looping documented; stale crash FAQ (issue #4) refreshed.
- CLAUDE.md: reset/END design decisions and edge cases recorded; stale issue-state notes removed; post-push CI artifact instructions added.

Tested by the owner on mac-arm64 via the CI artifacts: manual resets, gapless END → RESET looping, missing-data (NaN) columns, reload and patch round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HkSJfsKbFSrafrQdxpBvF

---
_Generated by [Claude Code](https://claude.ai/code/session_015HkSJfsKbFSrafrQdxpBvF)_