### PR TITLE
Break the display line with a notch at missing datapoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,13 @@ it) and restart Rack.
   clock, no quantizer, no sound generation. Musicality comes from the patch
   (external clock into TRIG, quantizer after V/OCT). Stay modular-idiomatic.
 - Missing/non-numeric CSV cells become NaN: excluded from min/max, produce no
-  gate (missing data is audible as silence).
+  gate (missing data is audible as silence). In the display, a gap breaks
+  the line with a notch: the line reaches ¾ of a step past the valid
+  points on either side, so an isolated valid point still shows as a
+  short fragment. Notches under a pixel wide (dense data, short gaps)
+  are drawn straight through; long gaps stay visible at any density.
+  Missing points before the first / after the last valid point draw
+  nothing.
 - V/oct RANGE mapping is intentionally asymmetric: ranges 1-3 octaves span
   0V..+range; 4-8 pin the top at +4V and grow downward.
 - Looping is done by the user patching END → RESET, not built in. RESET

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -553,28 +553,64 @@ struct DataViz : Widget
 				// Avoid dividing by zero when placing a single datapoint
 				float xdivisor = std::max(len - 1, 1);
 
-				// Draw the line
+				// Draw the line. Consecutive valid datapoints are joined
+				// directly; missing (NaN) datapoints break the line with a
+				// notch (issue #22): on each side of a gap the line reaches
+				// 3/4 of a step past the last valid point, sloping towards
+				// the next one, then stops. Since every valid point owns
+				// 3/4 of a step of line on each side, an isolated point
+				// between gaps still shows as a short fragment. A notch
+				// that would be under a pixel wide (very dense data) isn't
+				// visible anyway, so the line is drawn straight through
+				// instead — but long gaps stay visible even in dense data,
+				// because their notch is wide. Missing points before the
+				// first or after the last valid point draw nothing.
+				float stepx = width / xdivisor; // gap between datapoints
+				float reach = 0.75f * stepx;	// how far stubs extend
+
 				nvgBeginPath(args.vg);
-				bool firstpoint = true;
-				nvgMoveTo(args.vg, margin, height);
+				int prev = -1; // index of the previous valid datapoint
+				float prevx = 0.f;
+				float prevy = 0.f;
 
 				for (int d = 0; d < len; d++)
 				{
-					if (!std::isnan(ds->data[d])) {
-						// Calculate x and y coords
-						float x = margin + (d * width / xdivisor);
-						// Y == zero at the TOP of the box.
-						float y = (height - 3) - (scalemap(ds->data[d], ds->datamin, ds->datamax,
-													0.f, height-6));
+					if (std::isnan(ds->data[d])) {
+						continue;
+					}
 
-						if (firstpoint) {
-							nvgMoveTo(args.vg, x, y);
-							firstpoint = false;
+					// Calculate x and y coords
+					float x = margin + (d * stepx);
+					// Y == zero at the TOP of the box.
+					float y = (height - 3) - (scalemap(ds->data[d], ds->datamin, ds->datamax,
+												0.f, height-6));
+
+					if (prev < 0) {
+						// First valid datapoint: start the line here
+						nvgMoveTo(args.vg, x, y);
+					} else if (d == prev + 1) {
+						// Adjacent to the previous one: join directly
+						nvgLineTo(args.vg, x, y);
+					} else {
+						// There's a gap of missing datapoints in between
+						float notch = (x - prevx) - 2.f * reach;
+						if (notch < 1.f) {
+							// Sub-pixel notch: draw straight through
+							nvgLineTo(args.vg, x, y);
 						} else {
+							// Stub out of the previous point, break, then
+							// stub into this one (y interpolated along the
+							// straight line between the two points)
+							float t = reach / (x - prevx);
+							nvgLineTo(args.vg, prevx + reach, prevy + (y - prevy) * t);
+							nvgMoveTo(args.vg, x - reach, y - (y - prevy) * t);
 							nvgLineTo(args.vg, x, y);
 						}
 					}
 
+					prev = d;
+					prevx = x;
+					prevy = y;
 				}
 
 				nvgStrokeColor(args.vg, color::fromHexString(module->faded));


### PR DESCRIPTION
Fixes #22.

Missing (NaN) datapoints now read as gaps in the display line instead of being silently bridged:

- On each side of a run of missing datapoints, the line extends **¾ of a step** past the last valid point, sloping towards the next one, then breaks. The notch for a single missing point is half a step wide.
- Because every valid point keeps ¾ of a step of line on each side, an **isolated point** between gaps still shows as a short line fragment rather than vanishing.
- Notches that would be **under a pixel wide** (dense data with short gaps) are drawn straight through — the gap wouldn't be visible anyway — while long gaps produce wide notches that stay visible at any density.
- Missing points **before the first or after the last** valid datapoint draw nothing, as before. The playhead and cue circles keep their existing disappear-on-NaN behaviour.

Implemented by splitting the stroke path (`lineTo`/`moveTo`) rather than overdrawing with background-coloured rectangles, so there's no dependence on the panel colour and no extra drawing cost at any dataset size.

Tested by the owner on mac-arm64 via the CI artifact with sparse (14-point), medium (60-point), dense (2,000-point with a 200-point gap), and two-valid-points-only CSVs, plus a no-gaps regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HkSJfsKbFSrafrQdxpBvF

---
_Generated by [Claude Code](https://claude.ai/code/session_015HkSJfsKbFSrafrQdxpBvF)_