### PR TITLE
Embed data in patches; explain the RANGE mapping in its tooltip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,16 @@ it) and restart Rack.
   Missing points before the first / after the last valid point draw
   nothing.
 - V/oct RANGE mapping is intentionally asymmetric: ranges 1-3 octaves span
-  0V..+range; 4-8 pin the top at +4V and grow downward.
+  0V..+range; 4-8 pin the top at +4V and grow downward. `voctRange()`
+  implements it and the knob's tooltip (`RangeQuantity`) spells out the
+  exact span, so the behaviour explains itself in the UI.
+- Patches embed the selected column's data (JSON nulls for NaN), capped
+  at 10k values because dataToJson runs on every autosave; bigger
+  datasets stay path-only. On open, the CSV file wins if it's readable
+  (so edits show up); the embedded copy is the fallback, and in that
+  state column switching is locked (`embeddedonly`) until
+  "Reload CSV from disk" succeeds. A reload with the file still missing
+  shows the invalid-CSV state rather than silently keeping stale data.
 - Looping is done by the user patching END → RESET, not built in. RESET
   arms rather than plays: it returns the playhead to datapoint 0 with no
   gate, holding the CV outputs, and the next TRIG plays datapoint 0 in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,9 @@ it) and restart Rack.
   (so edits show up); the embedded copy is the fallback, and in that
   state column switching is locked (`embeddedonly`) until
   "Reload CSV from disk" succeeds. A reload with the file still missing
-  shows the invalid-CSV state rather than silently keeping stale data.
+  shows the error state rather than silently keeping stale data; the
+  display distinguishes "CSV file not found" (with a reload hint) from
+  "Invalid CSV" (file present but unparseable) via `filemissing`.
 - Looping is done by the user patching END → RESET, not built in. RESET
   arms rather than plays: it returns the playhead to datapoint 0 with no
   gate, holding the CV outputs, and the next TRIG plays datapoint 0 in

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Right-click to load a CSV file, and then right-click again to select a column of
 
 Your CSV file must have a single header row containing column names, and you'll only be able to sonify columns containing numbers. Any missing or non-numeric values in your data will be replaced with null values that don't fire a gate.
 
+Your data is saved inside the patch file (up to 10,000 values), so a patch keeps playing even if you share it with someone else or the CSV file gets moved or deleted. If the file is still where it was, it's re-read when the patch opens, so edits to it show up — and you can right-click → *Reload CSV from disk* to re-read it at any time. Without the file, the patch plays its embedded copy and the column menu is locked until a reload succeeds.
+
 Send a trigger signal into the TRIG input to process the first datapoint and move to the next one. Send a trigger into the RESET input to return to the start of the dataset — nothing plays until the next trigger arrives at TRIG, which plays the first datapoint in time with your clock. The END output fires a trigger as the last datapoint plays, so patching END → RESET loops the dataset seamlessly.
 
-The top two outputs generate voltages from -5V to 5V and 0 to 10V respectively. The lower left output generates 1V/Oct pitch CV, scaled to the number of octaves selected using the RANGE knob. The lower right output generates a gate as each new datapoint is processed - change the lenth of this gate with the LENGTH knob.
+The top two outputs generate voltages from -5V to 5V and 0 to 10V respectively. The lower left output generates 1V/Oct pitch CV, scaled to the number of octaves selected using the RANGE knob. Ranges of 1–3 octaves rise from 0V; from 4 octaves upward the top pitch stays pinned at +4V and wider ranges add lower notes instead of ever-higher ones — hover over the knob to see the exact voltage span. The lower right output generates a gate as each new datapoint is processed - change the lenth of this gate with the LENGTH knob.
 
 ## FAQ
 

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -499,10 +499,18 @@ struct LoudNumbers : Module
 	// data.
 	void reloadCSV()
 	{
-		std::shared_ptr<const Dataset> ds = getDataset();
-		if (colnum >= 0 && colnum < (int)ds->columns.size())
+		// Take the column name to restore from the live dataset — but
+		// NOT in the invalid-CSV state, where the live dataset doesn't
+		// reflect the file (it's whatever loaded before, or the default
+		// data): overwriting savedcolname from it would clobber the
+		// column name remembered from the patch.
+		if (!badcsv)
 		{
-			savedcolname = ds->columns[colnum];
+			std::shared_ptr<const Dataset> ds = getDataset();
+			if (colnum >= 0 && colnum < (int)ds->columns.size())
+			{
+				savedcolname = ds->columns[colnum];
+			}
 		}
 		processCSV(currentpath, COLUMN_RESTORE);
 	}

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -27,6 +27,45 @@ float scalemap(float x, float inmin, float inmax, float outmin, float outmax)
 	return outmin + (outmax - outmin) * ((x - inmin) / (inmax - inmin));
 };
 
+// The V/oct span for a given RANGE knob value. The mapping is
+// deliberately asymmetric: ranges of 1-3 octaves span 0V up to +range,
+// but from 4 octaves the top pins at +4V and the range grows downward.
+// That's because most users patch oscillators from somewhere mid-range,
+// and going more than ~4 octaves up from there is rarely useful — so a
+// wide range adds low notes rather than ever-higher ones. Shared by the
+// audio path (setCVOutputs) and the RANGE knob's tooltip.
+static void voctRange(float range, float &voctmin, float &voctmax)
+{
+	if (range < 4)
+	{
+		voctmin = 0;
+		voctmax = range;
+	}
+	else
+	{
+		voctmin = 4 - range;
+		voctmax = 4;
+	}
+}
+
+// Custom tooltip for the RANGE knob (issue #19): the asymmetric octave
+// mapping above is impossible to discover from the panel, so spell out
+// the exact voltage span right where the user is looking when they turn
+// the knob, e.g. "2 octaves (0V to +2V)" or "6 octaves (-2V to +4V)".
+struct RangeQuantity : ParamQuantity
+{
+	std::string getDisplayValueString() override
+	{
+		int range = (int)std::round(getValue());
+		float voctmin;
+		float voctmax;
+		voctRange(range, voctmin, voctmax);
+		std::string lo = (voctmin == 0.f) ? "0V" : string::f("%gV", voctmin);
+		return string::f("%d octave%s (%s to +%gV)",
+						 range, (range == 1) ? "" : "s", lo.c_str(), voctmax);
+	}
+};
+
 // A complete snapshot of a loaded dataset: the numbers plus everything
 // calculated from them. Snapshots are never modified after being built —
 // loading new data builds a whole new snapshot and swaps it in. That swap
@@ -103,7 +142,7 @@ struct LoudNumbers : Module
 	LoudNumbers()
 	{
 		config(PARAMS_LEN, INPUTS_LEN, OUTPUTS_LEN, LIGHTS_LEN);
-		configParam(RANGE_PARAM, 1, 8, 2, "Octave range", " octaves");
+		configParam<RangeQuantity>(RANGE_PARAM, 1, 8, 2, "Octave range");
 		getParamQuantity(RANGE_PARAM)->snapEnabled = true;
 		configParam(LENGTH_PARAM, 0.001f, 1.f, 0.1f, "Gate length", " s");
 		configInput(TRIG_INPUT, "Trigger");
@@ -143,6 +182,17 @@ struct LoudNumbers : Module
 	std::string savedcolname; // column name restored from a saved patch
 	bool csvloaded = false;
 
+	// Set when the module is playing the copy of the data embedded in
+	// the patch because the CSV file couldn't be read (issue #18). Only
+	// the selected column's data is embedded, so column switching is
+	// locked in the menu until a reload from disk succeeds.
+	bool embeddedonly = false;
+
+	// Datasets bigger than this aren't embedded in the patch: dataToJson
+	// runs on every autosave (~15s), and huge patches would make that
+	// slow. Those patches keep the old path-only behaviour.
+	static const int EMBED_MAX_VALUES = 10000;
+
 	// Values for colnum / the column request passed to processCSV()
 	static const int COLUMN_NONE = -1;	  // nothing selected: prompt the user
 	static const int COLUMN_AUTO = -2;	  // pick the first numeric column (new file)
@@ -177,7 +227,8 @@ struct LoudNumbers : Module
 	std::string white = "#FFFBE4";
 	std::string salmon = "#FF7272"; // panel background, fills the hollow circle
 
-	// Save and retrieve menu choice(s).
+	// Save and retrieve menu choice(s), plus a copy of the loaded data
+	// so the patch is portable (issue #18).
 	json_t* dataToJson() override {
 		if (csvloaded) {
 			json_t* rootJ = json_object();
@@ -189,6 +240,28 @@ struct LoudNumbers : Module
 			std::shared_ptr<const Dataset> ds = getDataset();
 			if (colnum >= 0 && colnum < (int)ds->columns.size()) {
 				json_object_set_new(rootJ, "default_column_name", json_string(ds->columns[colnum].c_str()));
+			}
+
+			// Save the column names and which of them hold numbers, so
+			// the column menu still makes sense without the file
+			json_t* columnsJ = json_array();
+			json_t* colhasdataJ = json_array();
+			for (size_t i = 0; i < ds->columns.size(); i++) {
+				json_array_append_new(columnsJ, json_string(ds->columns[i].c_str()));
+				json_array_append_new(colhasdataJ, json_boolean(ds->colhasdata[i]));
+			}
+			json_object_set_new(rootJ, "columns", columnsJ);
+			json_object_set_new(rootJ, "colhasdata", colhasdataJ);
+
+			// Embed the selected column's data, unless the dataset is
+			// over the embedding cap (see EMBED_MAX_VALUES)
+			if (colnum >= 0 && ds->length() > 0 && ds->length() <= EMBED_MAX_VALUES) {
+				json_t* dataJ = json_array();
+				for (float v : ds->data) {
+					// JSON has no NaN, so missing values become nulls
+					json_array_append_new(dataJ, std::isnan(v) ? json_null() : json_real(v));
+				}
+				json_object_set_new(rootJ, "data", dataJ);
 			}
 			return rootJ;
 		} else {
@@ -212,7 +285,68 @@ struct LoudNumbers : Module
 			currentpath = p;
 			processCSV(currentpath, COLUMN_RESTORE);
 			csvloaded = true;
+
+			// If the file couldn't be read — moved, renamed, deleted, or
+			// the patch came from someone else's computer — fall back to
+			// the copy of the data embedded in the patch. When the file
+			// IS readable it wins, so editing the CSV and reopening the
+			// patch still picks up the edits.
+			if (badcsv) {
+				loadEmbeddedData(rootJ);
+			}
 		}
+	}
+
+	// Build a dataset from the data embedded in the patch, used when the
+	// original CSV file can't be read. Leaves the invalid-CSV state
+	// untouched if the patch has no embedded data (it predates embedding,
+	// or the dataset was over the embedding cap).
+	void loadEmbeddedData(json_t* rootJ)
+	{
+		json_t* dataJ = json_object_get(rootJ, "data");
+		if (!dataJ || json_array_size(dataJ) == 0) {
+			return;
+		}
+
+		auto ds = std::make_shared<Dataset>();
+
+		// The embedded column data (nulls are missing values)
+		size_t i;
+		json_t* v;
+		json_array_foreach(dataJ, i, v) {
+			ds->data.push_back(json_is_number(v) ? (float)json_number_value(v) : NAN);
+		}
+		ds->calcMinMax();
+
+		// The column names, so the menu still lists them (locked)
+		json_t* columnsJ = json_object_get(rootJ, "columns");
+		json_t* colhasdataJ = json_object_get(rootJ, "colhasdata");
+		if (columnsJ) {
+			json_array_foreach(columnsJ, i, v) {
+				const char* name = json_string_value(v);
+				ds->columns.push_back(name ? name : "");
+				json_t* h = colhasdataJ ? json_array_get(colhasdataJ, i) : NULL;
+				ds->colhasdata.push_back(h ? json_is_true(h) : false);
+			}
+		}
+		if (ds->columns.empty()) {
+			// Shouldn't happen, but keep the menu and display sane
+			ds->columns.push_back(savedcolname.empty() ? "Embedded data" : savedcolname);
+			ds->colhasdata.assign(1, true);
+		}
+		if (colnum < 0 || colnum >= (int)ds->columns.size()) {
+			colnum = 0;
+		}
+
+		// Publish, same as the end of processCSV()
+		row = -1;
+		resetarmed = false;
+		playingrow = -1;
+		cued = true;
+		setDataset(ds);
+		badcsv = false;
+		embeddedonly = true;
+		INFO("using embedded data: %i values", ds->length());
 	}
 
 	// Trigger for incoming gate detection
@@ -225,21 +359,10 @@ struct LoudNumbers : Module
 	// checks that r is in range and not a NaN (missing) value.
 	void setCVOutputs(const Dataset &ds, int r)
 	{
-		// Get v/oct min and max: ranges of 1-3 octaves span 0V up to
-		// +range; from 4 octaves the top pins at +4V and grows downward.
+		// Get v/oct min and max from the RANGE knob (see voctRange)
 		float voctmin;
 		float voctmax;
-
-		if (params[RANGE_PARAM].getValue() < 4)
-		{
-			voctmin = 0;
-			voctmax = params[RANGE_PARAM].getValue();
-		}
-		else
-		{
-			voctmin = 4 - params[RANGE_PARAM].getValue();
-			voctmax = 4;
-		}
+		voctRange(params[RANGE_PARAM].getValue(), voctmin, voctmax);
 
 		// Set the voltages to the data
 		outputs[MINUSFIVETOFIVE_OUTPUT].setVoltage(scalemap(ds.data[r], ds.datamin, ds.datamax, -5.f, 5.f));
@@ -367,6 +490,21 @@ struct LoudNumbers : Module
 		// Load it, auto-selecting the first numeric column
 		processCSV(path, COLUMN_AUTO);
 		csvloaded = true;
+	}
+
+	// Re-read the current CSV from disk (context menu), keeping the
+	// selected column — matched by name, in case the file's columns have
+	// been reordered by an edit. If the file can't be read this shows
+	// the usual invalid-CSV state rather than silently keeping stale
+	// data.
+	void reloadCSV()
+	{
+		std::shared_ptr<const Dataset> ds = getDataset();
+		if (colnum >= 0 && colnum < (int)ds->columns.size())
+		{
+			savedcolname = ds->columns[colnum];
+		}
+		processCSV(currentpath, COLUMN_RESTORE);
 	}
 
 	// Load a CSV file and select a column to sonify. 'request' is either a
@@ -508,6 +646,7 @@ struct LoudNumbers : Module
 			cued = true; // show the hollow circle: cued at the start
 			setDataset(ds);
 			badcsv = false;
+			embeddedonly = false; // this data came from a real file
 
 		} catch (...) {
 			badcsv = true;
@@ -748,6 +887,16 @@ struct LoudNumbersWidget : ModuleWidget
 										  module->loadCSV();
 									  }));
 
+		// Re-read the current file from disk (e.g. after editing it)
+		if (module->csvloaded)
+		{
+			menu->addChild(createMenuItem("Reload CSV from disk", "",
+										  [=]()
+										  {
+											  module->reloadCSV();
+										  }));
+		}
+
 		// Spacer
 		menu->addChild(new MenuSeparator());
 
@@ -761,8 +910,10 @@ struct LoudNumbersWidget : ModuleWidget
 			item->val = i;
 			item->module = module;
 			// Columns with no numeric values can't be sonified, so grey
-			// them out
-			item->disabled = !ds->colhasdata[i];
+			// them out. When playing patch-embedded data (the CSV file
+			// couldn't be read), only the selected column's data exists,
+			// so the whole list is locked until a reload succeeds.
+			item->disabled = !ds->colhasdata[i] || module->embeddedonly;
 			menu->addChild(item);
 		}
 	}

--- a/src/LoudNumbers.cpp
+++ b/src/LoudNumbers.cpp
@@ -198,6 +198,11 @@ struct LoudNumbers : Module
 	static const int COLUMN_AUTO = -2;	  // pick the first numeric column (new file)
 	static const int COLUMN_RESTORE = -3; // restore a saved patch's column by name
 	std::atomic<bool> badcsv{false};
+	// When badcsv is set, this says which kind of problem it was: the
+	// file is missing (moved/renamed/deleted — fixable by putting it
+	// back and reloading) versus present but unparseable. The display
+	// words its message accordingly.
+	std::atomic<bool> filemissing{false};
 	std::atomic<int> row{-1}; // because the first thing we do is increment it
 
 	// Set when a reset has moved the playhead back to the first datapoint
@@ -522,6 +527,15 @@ struct LoudNumbers : Module
 		INFO("Processing CSV: %s", path.c_str());
 
 		try {
+			// Distinguish a missing file from an unparseable one, so the
+			// display can tell the user which problem they have
+			if (!system::isFile(path))
+			{
+				filemissing = true;
+				throw std::runtime_error("file not found");
+			}
+			filemissing = false;
+
 			// Setting values that aren't numbers to NaN (rather than throwing error)
 			rapidcsv::Document doc(path,
 								rapidcsv::LabelParams(),
@@ -683,7 +697,15 @@ struct DataViz : Widget
 				nvgFillColor(args.vg, color::fromHexString(module->white));
 				nvgFontSize(args.vg, 14);
 				nvgTextAlign(args.vg, NVG_ALIGN_CENTER);
-				nvgText(args.vg, width/2, height/2, "Invalid CSV", NULL);
+				if (module->filemissing) {
+					// The file has moved rather than being unreadable:
+					// tell the user how to fix it
+					nvgText(args.vg, width/2, height/2 - 16, "CSV file not found", NULL);
+					nvgText(args.vg, width/2, height/2, "Right-click to reload", NULL);
+					nvgText(args.vg, width/2, height/2 + 16, "or load a new file", NULL);
+				} else {
+					nvgText(args.vg, width/2, height/2, "Invalid CSV", NULL);
+				}
 			} else if (module->colnum < 0) {
 				// A file is loaded but no column is selected (e.g. a saved
 				// patch's column no longer exists in the file)


### PR DESCRIPTION
Fixes #18. Fixes #19.

## Patch portability (#18)

- `dataToJson` now embeds the selected column's data (JSON nulls standing in for NaN), plus the column names and which columns are numeric, so a patch keeps playing when the CSV file has been moved, renamed, deleted, or never existed on the recipient's machine.
- On load the **file still wins** if it's readable, so edit-and-reopen workflows are unchanged; the embedded copy is only the fallback. In that fallback state column switching is locked in the menu (only the selected column's data travels) until a reload from disk succeeds.
- Datasets over **10,000 values** aren't embedded — `dataToJson` runs on every autosave, and huge patches would make it slow — and keep the old path-only behaviour. The column name and list are saved regardless of the cap, so the selection survives either way.
- New context menu item **"Reload CSV from disk"** re-reads the file on demand, matching the current column by name (robust to reordered columns). If the file is unreadable it shows the error state rather than silently keeping stale data.
- The display now distinguishes **"CSV file not found"** (with a reload hint) from **"Invalid CSV"** (file present but unparseable).
- Bug fixed during testing: reloading from the error state no longer clobbers the remembered column name, so a restored file resumes on the column the patch saved.

## RANGE tooltip (#19)

- The knob tooltip now spells out the asymmetric octave mapping, e.g. "2 octaves (0V to +2V)" or "6 octaves (-2V to +4V)", via a custom `ParamQuantity`. The mapping is factored into `voctRange()`, shared by the audio path and the tooltip so they can't drift.

Both behaviours documented in README and CLAUDE.md.

Tested by the owner on mac-arm64 via the CI artifacts: tooltip sweep; save → rename file → reopen (embedded playback, locked menu, not-found message); reload after restoring the file (column remembered); file-wins-on-edit; over-cap path-only fallback; pre-existing patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HkSJfsKbFSrafrQdxpBvF

---
_Generated by [Claude Code](https://claude.ai/code/session_015HkSJfsKbFSrafrQdxpBvF)_