### PR TITLE
Don't clobber release notes from CI; update README for 2.1.0

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -110,13 +110,14 @@ jobs:
             echo "Plugin version from plugin.json 'v$pluginversion' doesn't match with tag version '${{ env.CI_REF_NAME }}'"
             exit 1
           fi
+      # No name/body here: if a release for this tag already exists (e.g. a
+      # hand-written draft that was published), leave its title and notes
+      # alone instead of overwriting them. A release created from scratch
+      # gets the tag name as its title and empty notes.
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
-          name: Release ${{ env.CI_REF_NAME }}
-          body: |
-            ${{ env.CI_REPOSITORY_NAME }} VCV Rack Plugin ${{ env.CI_REF_NAME }}
           draft: false
           prerelease: false
       - uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -4,19 +4,23 @@ A free VCV Rack plugin for data sonification.
 
 ## Installation
 
-Install from the VCV Rack library.
+Install from the VCV Rack library. Alternatively, download the `.vcvplugin` file for your platform from the [releases page](https://github.com/loudnumbers/loudnumbers_vcv/releases) and drop it into your Rack `plugins` folder.
 
 ## How to use
 
 Right-click to load a CSV file, and then right-click again to select a column of data from that file.
 
-Your CSV file must have a single header row containing column names, and you'll only be able to sonify columns containing numbers. Any missing or non-numeric values in your data will be replaced with null values that don't fire a gate.
+Your CSV file must have a single header row containing column names, and you'll only be able to sonify columns containing numbers. Any missing or non-numeric values in your data will be replaced with null values that don't fire a gate, and show as gaps in the display.
+
+Files don't have to be comma-separated: the delimiter is detected automatically, and you can override it from the right-click menu (comma, tab, semicolon, or any custom character) — so tab-separated `.tsv` and other delimited `.txt` files work too.
 
 Your data is saved inside the patch file (up to 10,000 values), so a patch keeps playing even if you share it with someone else or the CSV file gets moved or deleted. If the file is still where it was, it's re-read when the patch opens, so edits to it show up — and you can right-click → *Reload CSV from disk* to re-read it at any time. Without the file, the patch plays its embedded copy and the column menu is locked until a reload succeeds.
 
 Send a trigger signal into the TRIG input to process the first datapoint and move to the next one. Send a trigger into the RESET input to return to the start of the dataset — nothing plays until the next trigger arrives at TRIG, which plays the first datapoint in time with your clock. The END output fires a trigger as the last datapoint plays, so patching END → RESET loops the dataset seamlessly.
 
-The top two outputs generate voltages from -5V to 5V and 0 to 10V respectively. The lower left output generates 1V/Oct pitch CV, scaled to the number of octaves selected using the RANGE knob. Ranges of 1–3 octaves rise from 0V; from 4 octaves upward the top pitch stays pinned at +4V and wider ranges add lower notes instead of ever-higher ones — hover over the knob to see the exact voltage span. The lower right output generates a gate as each new datapoint is processed - change the lenth of this gate with the LENGTH knob.
+You can also jump around the data with the mouse: hover over the display to highlight a datapoint, and click it to cue it up — it plays on the next trigger, and playback continues from there. A hollow circle on the display marks the datapoint that's cued to play next; a filled circle marks the one you're hearing.
+
+The top two outputs generate voltages from -5V to 5V and 0 to 10V respectively. The lower left output generates 1V/Oct pitch CV, scaled to the number of octaves selected using the RANGE knob. Ranges of 1–3 octaves rise from 0V; from 4 octaves upward the top pitch stays pinned at +4V and wider ranges add lower notes instead of ever-higher ones — hover over the knob to see the exact voltage span. The lower right output generates a gate as each new datapoint is processed - change the length of this gate with the LENGTH knob.
 
 ## FAQ
 


### PR DESCRIPTION
Two post-release housekeeping changes:

- **Workflow**: the publish job no longer passes a title/body to the release step, so publishing a hand-written draft release keeps its notes when CI attaches the binaries (v2.1.0's notes were overwritten with generic text).
- **README**: document the delimiter selection and `.tsv`/`.txt` support (#16), the click-to-cue interaction and playhead circles (#14), gaps in the display for missing data, and manual installation from the releases page. Fix a "lenth" typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wow6minPi8rf8pmW8hBaNs)_